### PR TITLE
docs: fix broken links (ISSUES and PULL-REQUESTS)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing
 
-When contributing a major change to this repository, please first discuss the change you wish to make via an [issue](contributing/ISSUES.md) or via
+When contributing a major change to this repository, please first discuss the change you wish to make via an [issue](docs/contributing/ISSUES.md) or via
 [Slack in the #code-of-conduct channel](https://callforcode.org/slack). Minor issues can simply be addressed by sending by a pull request.
 
-All [pull requests](contributing/PULL-REQUESTS.md) will require you to ensure the change is certified via the [Developer Certificate of Origin (DCO)](https://github.com/apps/dco/). The DCO is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
+All [pull requests](docs/contributing/PULL-REQUESTS.md) will require you to ensure the change is certified via the [Developer Certificate of Origin (DCO)](https://github.com/apps/dco/). The DCO is a lightweight way for contributors to certify that they wrote or otherwise have the right to submit the code they are contributing to the project.
 
 Please note we have a [Code of Conduct](#code-of-conduct), please follow it in all your interactions with the project and its community.
 


### PR DESCRIPTION
# Cause of the problem
The two links in the `CONTRIBUTING.md` were giving a 404 redirection error. It turns out the problem was that the links were missing the `doc` directory.

# Fix
Change from:
\[issue](contributing/ISSUES.md) ... \[pull requests](contributing/PULL-REQUESTS.md)

Change to:
\[issue](docs/contributing/ISSUES.md) ... \[pull requests](docs/contributing/PULL-REQUESTS.md)